### PR TITLE
Updated deps, logic for same-host config

### DIFF
--- a/docker-compose.monitoring-host.yml
+++ b/docker-compose.monitoring-host.yml
@@ -13,8 +13,7 @@ services:
   statistics_crawler:
     restart: unless-stopped
     image: python:3.10-alpine
-    networks:
-      - monitoring_internal
+    network_mode: "host"
     command: "python /crawl.py ${pixelflut_host} ${pixelflut_port_statistics} /tmp/pixelflut_statistics.txt"
     volumes:
       - "./statistics_crawler/crawl.py:/crawl.py"

--- a/vncmux/Dockerfile
+++ b/vncmux/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 RUN apk add --no-cache \
     build-base=0.5-r2 \
     git=2.34.1-r0 \
-    ca-certificates=20191127-r7 \
+    ca-certificates=20211220-r0 \
     && \
     git clone https://github.com/tobleminer/vncmux && \
     cd vncmux && \


### PR DESCRIPTION
vncmux/Dockerfile: Die Version von ca-certificates musste angehoben werden, andernfalls lässt sich der Container nicht bauen.

docker-compose.monitoring-host.yml: Wenn der Monitor auf dem gleichen Host läuft wie der Shorline funktioniert "localhost" als pixelflut_host nicht. Auch kein anderer relativer DNS Pfad funktioniert. Dass "localhost" funktioniert, muss der Container ebenfalls im lokalen host network_mode laufen. Werden die Container auf getrennten Systemen laufen sollte diese Änderung auch funktionieren.